### PR TITLE
Don't fail on 204 from direct_upload endpoint

### DIFF
--- a/majortom_gateway/gateway_api.py
+++ b/majortom_gateway/gateway_api.py
@@ -360,7 +360,7 @@ class GatewayAPI:
                 headers=headers,
                 data=file_handle)
 
-        if upload_r.status_code != 200:
+        if upload_r.status_code not in (200, 204):
             logger.error(
                 f"Transaction Failed. Status code: {upload_r.status_code} \n Text Response: {upload_r.text}")
             raise(RuntimeError(f"File Upload Request Failed. Status code: {upload_r.status_code}"))


### PR DESCRIPTION
Currently the `downlink_file` command will fail if it receives a `204` from `direct_upload`. `204` is a successful response in this case because nothing is needed or being expected in the response body.

This fixes `downlink_file` when running the Major Tom dev environment locally without docker.