### PR TITLE
Fix asyncio import for Python 3.8

### DIFF
--- a/majortom_gateway/gateway_api.py
+++ b/majortom_gateway/gateway_api.py
@@ -10,6 +10,12 @@ import traceback
 from base64 import b64encode
 import requests
 import hashlib
+try:
+    # python <= 3.7:
+    from asyncio.streams import IncompleteReadError
+except ImportError:
+    # python >= 3.8:
+    from asyncio.exceptions import IncompleteReadError
 
 import websockets
 
@@ -83,7 +89,7 @@ class GatewayAPI:
         while True:
             try:
                 return await self.connect()
-            except (OSError, asyncio.streams.IncompleteReadError, websockets.ConnectionClosed) as e:
+            except (OSError, IncompleteReadError, websockets.ConnectionClosed) as e:
                 self.websocket = None
                 logger.warning("Connection error encountered, retrying in 5 seconds ({})".format(e))
                 await asyncio.sleep(5)


### PR DESCRIPTION
We are catching the IncompleteReadError exception from asyncio, but
before Python 3.8 it was asyncio.streams.IncompleteReadError, and now it
is asyncio.exceptions.IncompleteReadError (or just
asyncio.IncompleteReadError). So let's try importing one then fall back
to the other. That's the approach aiomysql takes:
https://github.com/dongweiming/aiomysql/commit/fd4174f8e7f09fe8295cb066c8adf99ae99e3670