### PR TITLE
bump version

### DIFF
--- a/majortom_gateway/gateway_api.py
+++ b/majortom_gateway/gateway_api.py
@@ -264,7 +264,7 @@ class GatewayAPI:
 
     async def transmit_blob(self, blob: bytes, context: dict):
         # Transmit bytes to a satellite via a groundstation network. The required context depends on the specific
-        # gsn. Version is always required.
+        # gsn.
         await self._validate_context(context)
         await self.transmit({
             "type": "transmit_blob",
@@ -273,8 +273,7 @@ class GatewayAPI:
         })
 
     async def _validate_context(self, context: dict):
-        if 'version' not in context:
-            raise MissingContextError("Context is missing version number.")
+        # Stub for validating context. Raise MissingContextError if it fails
         return True
 
     async def fail_command(self, command_id: int, errors: list):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-VERSION = "0.0.9"
+VERSION = "0.1.0"
 
 with open("README.md", "r") as readme:
     readme_content = readme.read()
@@ -19,9 +19,13 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Intended Audience :: Developers",
+        "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent"
     ],


### PR DESCRIPTION
Also remove the interior version number. We can use package version to
enforce.

This should have been included with the addition of `context` to blob callback.