### PR TITLE
Add Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,6 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
-      # run tests!
-      # this example uses Django's built-in test-runner
-      # other common Python testing frameworks include pytest and nose
-      # https://pytest.org
-      # https://nose.readthedocs.io
       - run:
           name: run tests
           command: |
@@ -53,3 +48,9 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.6.1
 
 WORKDIR /app
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM python:3.8
+
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN pip install -r requirements.txt
+COPY . /app
+
+CMD ["ptw","--","-v","--cache-clear"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ as an example of how to use it!
 
 The `connect` or `connect_with_retries` functions must be called before any messages can be passed.
 
+## Development
+
 The Gateway API Package is currently in Beta,
 so please [submit an issue](https://github.com/kubos/majortom_gateway_package/issues/new)
 or [come talk to us](https://slack.kubos.com) if you have any comments/questions/feedback.
+
+### Testing 
+
+To run tests continouosly, execute `./dockertest.sh`.
+
+To examine the testing environment, execute `./dockertest.sh bash`.

--- a/dockertest.sh
+++ b/dockertest.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker build -t gateway_api_test_container -f Dockerfile.test .
+docker run -it \
+    -v $(pwd):/app \
+    gateway_api_test_container $1

--- a/majortom_gateway/__init__.py
+++ b/majortom_gateway/__init__.py
@@ -1,2 +1,3 @@
 from majortom_gateway.gateway_api import GatewayAPI
+from majortom_gateway.command import Command
 name = "majortom_gateway"

--- a/majortom_gateway/gateway_api.py
+++ b/majortom_gateway/gateway_api.py
@@ -129,8 +129,7 @@ class GatewayAPI:
                 """
                 asyncio.ensure_future(self.command_callback(command, self))
             else:
-                asyncio.ensure_future(self.fail_command(
-                    command.id, errors=["No command callback implemented"]))
+                asyncio.ensure_future(self.fail_command(command.id, errors=["No command callback implemented"]))
         elif message_type == "cancel":
             if self.cancel_callback is not None:
                 """
@@ -154,7 +153,6 @@ class GatewayAPI:
         elif message_type == "received_blob":
             if self.received_blob_callback is not None:
                 encoded = message["blob"]
-                logger.debug(encoded)
                 decoded = base64.b64decode(encoded)
                 context = message["context"]
                 asyncio.ensure_future(self.received_blob_callback(decoded, context, self))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli=true
+log_cli_level = DEBUG
+log_cli_format = %(asctime)s %(levelname)s %(message)s
+log_cli_date_format = %H:%M:%S

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 requests
 websockets
 pytest
+pytest-watch
+pytest-asyncio
 setuptools
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-requests
-websockets
-pytest
-pytest-watch
-pytest-asyncio
+mock>=4.0.3
+pytest-asyncio>=0.14.0
+pytest-only>=1.2.2
+pytest-watch>=4.2.0
+pytest>=6.2.2
+requests>=2.25.1
+websockets>=8.1
 setuptools
 wheel

--- a/test_gateway_class.py
+++ b/test_gateway_class.py
@@ -1,7 +1,0 @@
-import pytest
-from majortom_gateway import GatewayAPI
-
-
-def test_required_args():
-    with pytest.raises(TypeError):
-        gw = GatewayAPI()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,6 +1,11 @@
 import pytest
 import asyncio
-from unittest.mock import AsyncMock
+try:
+    # Python 3.8+
+    from unittest.mock import AsyncMock
+except ImportError:
+    # Python 3.6+
+    from mock import AsyncMock
 from unittest.mock import ANY
 from majortom_gateway import GatewayAPI
 from majortom_gateway import Command
@@ -20,7 +25,6 @@ def callback_mock():
     future.set_result(None)
     fn = AsyncMock(return_value=future) 
     return fn
-
 
 @pytest.mark.asyncio
 async def test_fails_when_no_command_callback(monkeypatch):

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,147 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import ANY
+from majortom_gateway import GatewayAPI
+from majortom_gateway import Command
+import json
+import base64
+
+class TypeMatcher:
+    def __init__(self, expected_type):
+        self.expected_type = expected_type
+
+    def __eq__(self, other):
+        return isinstance(other, self.expected_type)
+
+@pytest.fixture
+def callback_mock():
+    future = asyncio.Future()
+    future.set_result(None)
+    fn = AsyncMock(return_value=future) 
+    return fn
+
+
+@pytest.mark.asyncio
+async def test_fails_when_no_command_callback(monkeypatch):
+    gw = GatewayAPI("host", "gateway_token")
+
+    # Monkey-patch fail command, which should be called when a command callback doesn't exist
+    mock_fail_command = AsyncMock()
+    monkeypatch.setattr(gw, "fail_command", mock_fail_command)
+
+    message =  json.dumps({
+        "type": "command",
+        "command": {
+            "id": 4,
+            "type": "get_battery" ,
+            "system": "ISS",
+            "fields": []
+        }
+    })
+    res = await gw.handle_message(message)
+    
+    assert(None == res)
+    assert mock_fail_command.called
+
+@pytest.mark.asyncio
+async def test_calls_command_callback(callback_mock):
+    gw = GatewayAPI("host", "gateway_token", command_callback=callback_mock)
+    message =  json.dumps({
+        "type": "command",
+        "command": {
+            "id": 4,
+            "type": "get_battery" ,
+            "system": "ISS",
+            "fields": []
+        }
+    })
+
+    res = await gw.handle_message(message)
+    
+    # Make sure that the command callback was called with the command and Gateway
+    callback_mock.assert_called_once_with(TypeMatcher(Command), TypeMatcher(GatewayAPI))
+
+@pytest.mark.asyncio
+async def test_calls_cancel_callback(callback_mock):
+    gw = GatewayAPI("host", "gateway_token", cancel_callback=callback_mock)
+    message =  json.dumps({
+        "type": "cancel",
+        "timestamp": 1528391020767,
+        "command": {
+            "id": 20
+        }
+    })
+
+    res = await gw.handle_message(message)
+    
+    # The cancel callback is called with the command id and the gateway
+    callback_mock.assert_called_once_with(20, TypeMatcher(GatewayAPI))
+
+@pytest.mark.asyncio
+async def test_calls_rate_limit_callback(callback_mock):
+    gw = GatewayAPI("host", "gateway_token", rate_limit_callback=callback_mock)
+    message =  {
+        "type": "rate_limit",
+        "rate_limit": {
+            "rate": 60,
+            "retry_after": 0.5,
+            "error": "Rate limit exceeded. Please limit request rate to a burst of 20 and an average of 60/second.",
+        }
+    }
+
+    res = await gw.handle_message(json.dumps(message))
+    
+    # The rate limit callback is given the raw message
+    callback_mock.assert_called_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_calls_error_callback(callback_mock):
+    gw = GatewayAPI("host", "gateway_token", error_callback=callback_mock)
+    message = {
+        "type": "error",
+        "error": "This Gateway's token has been rotated. Please use the new one.",
+        "disconnect": True
+    }
+
+    res = await gw.handle_message(json.dumps(message))
+    
+    # The error callback is given the raw message
+    callback_mock.assert_called_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_calls_transit_callback(callback_mock):
+    gw = GatewayAPI("host", "gateway_token", transit_callback=callback_mock)
+    # ToDo: Update this example message
+    message =  {
+        "type": "transit",
+    }
+
+    res = await gw.handle_message(json.dumps(message))
+    
+    # The transit callback is given the raw message
+    callback_mock.assert_called_once_with(message)
+
+@pytest.mark.asyncio
+async def test_calls_received_blob_callback(callback_mock):
+    gw = GatewayAPI("host", "gateway_token", received_blob_callback=callback_mock)
+    blob = b"I am a blob"
+    message =  json.dumps({
+        "type": "received_blob",
+        "blob": base64.b64encode(blob).decode("utf-8"),
+        "context": {
+            "norad_id": 12345
+        },
+        "metadata": {
+            "gsn_timestamp": 1234567890,
+            "majortom_timestamp": 1234567890
+        }
+    })
+
+    res = await gw.handle_message(message)
+    
+    # The received_blob callback is given the decoded blob, the context, and the gateway
+    callback_mock.assert_called_once_with(blob, ANY, TypeMatcher(GatewayAPI))
+

--- a/tests/test_gateway_class.py
+++ b/tests/test_gateway_class.py
@@ -1,0 +1,15 @@
+import pytest
+from majortom_gateway import GatewayAPI
+import logging
+
+def test_logging_output():
+    # A simple test to see what output is being captured
+    logging.debug("DEBUG: Testing")
+    logging.info("INFO: Testing")
+    logging.warning("WARN: Testing")
+    logging.error("ERROR: Testing")
+    print("PRINT: Testing")
+
+def test_required_args():
+    with pytest.raises(TypeError):
+        gw = GatewayAPI()


### PR DESCRIPTION
Adds a whole bunch of asyncronous-friendly tests for callback mechanisms,
as well as a dockerized environment to run them. Modifies the circleci
config to (hopefully) run these tests on every branch and PR.