### PR TITLE
fix: handle None websocket after unexpected disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced deprecated `asyncio.iscoroutinefunction()` with `inspect.iscoroutinefunction()`
 
 ### Fixed
+- Fixed TypeError when websocket becomes None after unexpected disconnection during `empty_queue()`. Now properly raises `ConnectionClosed` to trigger retry instead of failing with "'async for' requires an object with __aiter__ method"
 - Fixed critical bug in `transmit_blob()` - changed from `base64.b64encode` to `b64encode` to match new imports
 - Fixed encoding inconsistency in blob transmission (now consistently uses UTF-8 instead of cp437)
 - Fixed race condition in `disconnect()` method by storing websocket reference before closing


### PR DESCRIPTION
## Summary
- Fix TypeError when websocket becomes None after unexpected disconnection during `empty_queue()`
- Now properly raises `ConnectionClosed` to trigger retry instead of failing with "'async for' requires an object with __aiter__ method"

## Problem
When the websocket connection is unexpectedly closed during `empty_queue()`, `self.websocket` gets set to None. Previously, the code would then attempt to iterate over None with `async for`, causing:

```
TypeError: 'async for' requires an object with __aiter__ method, got NoneType
```

This was reported by a user experiencing connection issues where the server closed the connection immediately after sending the hello message.

## Solution
Check if `self.websocket` is None after `empty_queue()` and raise `websockets.ConnectionClosed` to trigger proper retry logic in `connect_with_retries()`.

## Test plan
- [x] All existing tests pass (19/19)
- [ ] Manual testing with gateway that experiences disconnection during empty_queue