### PR TITLE
feat: make queue size configurable with lower default

### DIFF
--- a/majortom_gateway/__init__.py
+++ b/majortom_gateway/__init__.py
@@ -1,4 +1,4 @@
-from majortom_gateway.gateway_api import GatewayAPI
+from majortom_gateway.gateway_api import GatewayAPI, DEFAULT_MAX_QUEUE_SIZE
 from majortom_gateway.command import Command
 from majortom_gateway.exceptions import (
     GatewayAPIError,


### PR DESCRIPTION
## Summary
- Add `max_queue_size` parameter to `GatewayAPI` constructor, allowing users to control the maximum number of queued messages during disconnection
- Lower default from 10,000 to 100 to prevent excessive memory usage (previously up to ~800MB with large telemetry packets)
- Export `DEFAULT_MAX_QUEUE_SIZE` constant for user reference
- Validate `max_queue_size` input (must be non-negative integer)

## Context
Customer reported memory leak caused by unbounded queue growth during WebSocket disconnections. With ~80kB telemetry packets at 1Hz, the previous 10,000-item default allowed ~800MB of memory usage. The new default of 100 items caps memory at ~8MB while still covering typical short outages.

Users can customize via: `GatewayAPI("host", "token", max_queue_size=1000)`

## Test plan
- [x] Verify default queue size is 100
- [x] Verify custom queue size is respected
- [x] Verify queue size of 0 disables queueing
- [x] Verify negative and non-integer values are rejected
- [x] Verify queue drops messages when full
- [x] All 32 existing + new tests pass