### PR TITLE
docs: document configurable max_queue_size parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable `max_queue_size` parameter to control how many payloads are queued while disconnected (default: 100, previously unlimited)
+
 ## [0.1.5] - 2026-01-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ gateway = GatewayAPI(
     rate_limit_callback=handle_rate_limit,  # Optional: Handler for rate limit messages
     cancel_callback=handle_cancel,          # Optional: Handler for command cancellation
     transit_callback=handle_transit,        # Optional: Handler for ground station transits
-    received_blob_callback=handle_blob      # Optional: Handler for received binary data
+    received_blob_callback=handle_blob,     # Optional: Handler for received binary data
+    max_queue_size=100,                     # Optional: Max queued payloads when disconnected (default: 100)
 )
 ```
 
@@ -198,6 +199,7 @@ await gateway.disconnect()  # New async version
 - File operation errors now raise specific exceptions (`FileDownloadError`, `FileUploadError`) instead of `RuntimeError`
 - Input parameters are now validated at initialization with clear error messages via `ValidationError`
 - The `dict` parameter in `transmit_command_update()` has been renamed to `extra_fields`
+- The local message queue now defaults to a maximum of 100 items (previously unlimited). Payloads queued while disconnected will be dropped when the limit is reached. Set `max_queue_size` to a higher value if needed.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Add `max_queue_size` to README initialization parameters example
- Add queue size default change to migration guide
- Add configurable queue size to CHANGELOG unreleased section

## Test plan
- [x] Documentation-only change, no code changes