### PR TITLE
Fix websockets connect using legacy API instead of new asyncio API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Configurable `max_queue_size` parameter to control how many payloads are queued while disconnected (default: 100, previously unlimited)
 
+### Fixed
+- Fixed `TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'additional_headers'` by importing `connect` from `websockets.asyncio.client` (the new API) instead of using `websockets.connect` (which resolves to the legacy API even in websockets 13.x)
+
 ## [0.1.5] - 2026-01-13
 
 ### Added

--- a/majortom_gateway/gateway_api.py
+++ b/majortom_gateway/gateway_api.py
@@ -19,6 +19,7 @@ except ImportError:
     from asyncio.exceptions import IncompleteReadError
 
 import websockets
+from websockets.asyncio.client import connect as websockets_connect
 
 from majortom_gateway.command import Command
 
@@ -130,7 +131,7 @@ class GatewayAPI:
                 ssl_context.verify_mode = ssl.CERT_NONE
 
         logger.info("Connecting to Major Tom at {}".format(self.gateway_endpoint))
-        self.websocket = await websockets.connect(
+        self.websocket = await websockets_connect(
             self.gateway_endpoint,
             additional_headers=self.headers,
             ssl=ssl_context,

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -58,7 +58,7 @@ async def test_reconnects_on_connection_closed_error():
             gw.shutdown_intended = True
         return MockWebSocket(close_after=0)
 
-    with patch.object(websockets, 'connect', side_effect=mock_connect):
+    with patch('majortom_gateway.gateway_api.websockets_connect', side_effect=mock_connect):
         await gw.connect_with_retries()
 
     assert connect_count == max_connects, f"Expected {max_connects} connection attempts, got {connect_count}"
@@ -79,7 +79,7 @@ async def test_reconnects_on_abrupt_disconnect():
             gw.shutdown_intended = True
         return ws
 
-    with patch.object(websockets, 'connect', side_effect=mock_connect):
+    with patch('majortom_gateway.gateway_api.websockets_connect', side_effect=mock_connect):
         with patch('asyncio.sleep', new_callable=AsyncMock):
             await gw.connect_with_retries()
 
@@ -97,7 +97,7 @@ async def test_stops_reconnecting_on_intentional_disconnect():
         gw.shutdown_intended = True
         raise websockets.ConnectionClosed(None, None)
 
-    with patch.object(websockets, 'connect', side_effect=mock_connect):
+    with patch('majortom_gateway.gateway_api.websockets_connect', side_effect=mock_connect):
         await gw.connect_with_retries()
 
     assert connect_count == 1, "Should stop after intentional disconnect"
@@ -117,7 +117,7 @@ async def test_reconnects_on_os_error():
             raise websockets.ConnectionClosed(None, None)
         raise OSError("Connection refused")
 
-    with patch.object(websockets, 'connect', side_effect=mock_connect):
+    with patch('majortom_gateway.gateway_api.websockets_connect', side_effect=mock_connect):
         with patch('asyncio.sleep', new_callable=AsyncMock):
             await gw.connect_with_retries()
 


### PR DESCRIPTION
## Summary
- `websockets.connect` resolves to the legacy API (`websockets.legacy.client.Connect`) even in websockets 13.x, which expects `extra_headers` — not `additional_headers`
- This caused a `TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'additional_headers'` at runtime
- Fixed by importing `connect` directly from `websockets.asyncio.client`, which is the new API that accepts `additional_headers`
- Updated test patches to target the new import path

## Test plan
- [x] All 32 unit tests pass
- [x] Verified old code path produces the exact `TypeError` reported
- [x] Verified fix connects successfully to local Major Tom instance (received `hello` message)