### PR TITLE
fix: make file exceptions backward compatible with RuntimeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed `TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'additional_headers'` by importing `connect` from `websockets.asyncio.client` (the new API) instead of using `websockets.connect` (which resolves to the legacy API even in websockets 13.x)
 - Restored backward compatibility for `transmit_command_update(dict={...})` — the old `dict` keyword argument now works alongside the new `extra_fields` parameter
+- Restored backward compatibility for file operation exceptions — `FileDownloadError`, `FileUploadError`, and `FileTransferError` now also inherit from `RuntimeError` so existing `except RuntimeError` blocks still catch them
 
 ## [0.1.5] - 2026-01-13
 

--- a/majortom_gateway/exceptions.py
+++ b/majortom_gateway/exceptions.py
@@ -13,7 +13,7 @@ class ValidationError(GatewayAPIError):
     pass
 
 
-class FileTransferError(GatewayAPIError):
+class FileTransferError(GatewayAPIError, RuntimeError):
     """Base exception for file transfer operations."""
     pass
 

--- a/tests/test_gateway_class.py
+++ b/tests/test_gateway_class.py
@@ -13,3 +13,17 @@ def test_logging_output():
 def test_required_args():
     with pytest.raises(TypeError):
         gw = GatewayAPI()
+
+
+def test_file_exceptions_catchable_as_runtime_error():
+    """FileDownloadError and FileUploadError should be catchable as RuntimeError for backward compat."""
+    from majortom_gateway.exceptions import FileDownloadError, FileUploadError, FileTransferError
+
+    with pytest.raises(RuntimeError):
+        raise FileDownloadError("download failed")
+
+    with pytest.raises(RuntimeError):
+        raise FileUploadError("upload failed")
+
+    with pytest.raises(RuntimeError):
+        raise FileTransferError("transfer failed")


### PR DESCRIPTION
## Summary
- `FileTransferError` now inherits from both `GatewayAPIError` and `RuntimeError`
- This means `FileDownloadError` and `FileUploadError` are still catchable with `except RuntimeError`, preserving backward compatibility with code written against the pre-0.1.5 API
- Adds test verifying all three file exception types are catchable as `RuntimeError`

## Test plan
- [x] All 37 tests pass
- [x] Verified `FileDownloadError`, `FileUploadError`, and `FileTransferError` are all catchable as `RuntimeError`
- [x] Verified they're still catchable as `GatewayAPIError`