### PR TITLE
Add exponential backoff with jitter to WebSocket reconnect

### DIFF
--- a/majortom_gateway/gateway_api.py
+++ b/majortom_gateway/gateway_api.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import random
 import re
 import ssl
 import logging
@@ -170,12 +171,18 @@ class GatewayAPI:
                 "disconnect called but no open websocket connection exists"
             )
 
+    def _retry_delay(self, retry_count):
+        cap = 60
+        base = 1
+        return random.uniform(0, min(cap, base * 2 ** retry_count))
+
     async def connect_with_retries(self):
         retry_count = 0
         while True:
             try:
+                await self.connect()
                 retry_count = 0
-                return await self.connect()
+                return
             except (websockets.ConnectionClosed, websockets.ConnectionClosedError) as e:
                 if self.shutdown_intended:
                     self.websocket = None
@@ -184,13 +191,15 @@ class GatewayAPI:
                 else:
                     retry_count += 1
                     self.websocket = None
-                    logger.warning("Connection closed unexpectedly (attempt {}), retrying in 5 seconds. Error: {}".format(retry_count, str(e)))
-                    await asyncio.sleep(5)
+                    delay = self._retry_delay(retry_count)
+                    logger.warning("Connection closed unexpectedly (attempt {}), retrying in {:.1f} seconds. Error: {}".format(retry_count, delay, str(e)))
+                    await asyncio.sleep(delay)
             except (OSError, IncompleteReadError) as e:
                 retry_count += 1
                 self.websocket = None
-                logger.warning("Connection error encountered (attempt {}), retrying in 5 seconds. Error type: {}, Error: {}".format(retry_count, type(e).__name__, str(e)))
-                await asyncio.sleep(5)
+                delay = self._retry_delay(retry_count)
+                logger.warning("Connection error encountered (attempt {}), retrying in {:.1f} seconds. Error type: {}, Error: {}".format(retry_count, delay, type(e).__name__, str(e)))
+                await asyncio.sleep(delay)
             except websockets.InvalidStatusCode as e:
                 self.websocket = None
                 if e.status_code == 401:
@@ -203,8 +212,9 @@ class GatewayAPI:
                     raise e
                 elif e.status_code == 404 or e.status_code >= 500:
                     retry_count += 1
-                    logger.warning(f"Received {e.status_code} when trying to connect (attempt {retry_count}), retrying in 5 seconds.")
-                    await asyncio.sleep(5)
+                    delay = self._retry_delay(retry_count)
+                    logger.warning(f"Received {e.status_code} when trying to connect (attempt {retry_count}), retrying in {delay:.1f} seconds.")
+                    await asyncio.sleep(delay)
                 else:
                     e.args = [f"Unhandled status code returned: {e.status_code}"]
                     raise e

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -8,6 +8,7 @@ from majortom_gateway import GatewayAPI, DEFAULT_MAX_QUEUE_SIZE
 from majortom_gateway.exceptions import ValidationError
 import websockets
 import logging
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -272,3 +273,48 @@ async def test_transmit_command_update_extra_fields_takes_precedence():
     import json
     sent = json.loads(mock_ws.sent_messages[0])
     assert sent["command"]["output"] == "from extra_fields"
+
+
+def test_retry_delay_within_expected_range():
+    gw = GatewayAPI("host", "gateway_token")
+    for _ in range(100):
+        assert 0 <= gw._retry_delay(1) <= 2
+        assert 0 <= gw._retry_delay(2) <= 4
+        assert 0 <= gw._retry_delay(3) <= 8
+        assert 0 <= gw._retry_delay(4) <= 16
+        assert 0 <= gw._retry_delay(5) <= 32
+        assert 0 <= gw._retry_delay(6) <= 60
+
+
+def test_retry_delay_caps_at_60_seconds():
+    gw = GatewayAPI("host", "gateway_token")
+    for _ in range(100):
+        delay = gw._retry_delay(20)
+        assert 0 <= delay <= 60
+
+
+@pytest.mark.asyncio
+async def test_reconnect_uses_backoff():
+    gw = GatewayAPI("host", "gateway_token")
+    connect_count = 0
+    max_connects = 4
+    sleep_delays = []
+
+    async def mock_connect(*args, **kwargs):
+        nonlocal connect_count
+        connect_count += 1
+        if connect_count >= max_connects:
+            gw.shutdown_intended = True
+        raise websockets.ConnectionClosed(None, None)
+
+    async def mock_sleep(delay):
+        sleep_delays.append(delay)
+
+    with patch('majortom_gateway.gateway_api.websockets_connect', side_effect=mock_connect):
+        with patch('asyncio.sleep', side_effect=mock_sleep):
+            await gw.connect_with_retries()
+
+    assert len(sleep_delays) == max_connects - 1
+    assert sleep_delays[0] <= 2
+    assert sleep_delays[1] <= 4
+    assert sleep_delays[2] <= 8


### PR DESCRIPTION
## Summary

- Replaces fixed 5-second retry delay with exponential backoff using full jitter (AWS recommended pattern)
- Retry delays: `random.uniform(0, min(60, 1 * 2^attempt))` — ranges from 0-2s on first attempt up to 0-60s cap
- Fixes retry_count reset so it only resets after a clean disconnect, not after each connection establishment
- Prevents thundering herd when multiple gateways reconnect simultaneously after a server restart

## Context

During a production deploy on 2026-03-10, all 23 gateways lost their WebSocket connections simultaneously. With the fixed 5-second retry, all 23 retried in lockstep every 5 seconds, saturating the ELB surge queue and causing intermittent failures for all users for over 2 hours.

## Test plan

- [ ] Verify all existing reconnection tests still pass
- [ ] Verify retry delays fall within expected ranges (0-2s, 0-4s, 0-8s, etc.)
- [ ] Verify delays cap at 60 seconds
- [ ] Verify retry_count increments across reconnect attempts (not resetting each time)